### PR TITLE
Adding a fix for qdrant store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     ports:
       - 6333:6333
     volumes:
-      - /tmp/qdrant_storage:/qdrant/storage
+      - qdrant_storage:/qdrant/storage
     networks:
       - openchat_network
 
@@ -74,3 +74,4 @@ networks:
 volumes:
   shared_data:
   database:
+  qdrant_storage:


### PR DESCRIPTION
using anonymous volume instead of named volume


ref issue: Docker Compose issue during make install using Pinecone #127
