### PR TITLE
chat.js file will change based on where the server resides

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3'
 services:
   backend-server:
     restart: unless-stopped
-    image: codebanesr/openchat_backend_server:latest
+    build:
+      context: ./backend-server
+      dockerfile: Dockerfile
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
prebuilt images can't be used for server deployment, so they will have to be built for every vendor