### PR TITLE
Metadata will show now in chat more info.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dj_backend_server.code-workspace
 .aiderignore
 dj_backend_server/.vscode/settings.json
 
+dj_backend_server/a.py
+dj_backend_server/1.pdf

--- a/dj_backend_server/.vscode/settings.json
+++ b/dj_backend_server/.vscode/settings.json
@@ -2,5 +2,6 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    "python.formatting.provider": "none"
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": false
 }

--- a/dj_backend_server/CHANGELOG.MD
+++ b/dj_backend_server/CHANGELOG.MD
@@ -1,3 +1,6 @@
+2.22.2024
+- We've recently enhanced our chat interface to display metadata values, such as the data source and web links, from our vector database when available. However, it's important to note that, as of now, there is no option to toggle this feature on or off. This means that whenever this metadata is available for newer database entries, it will be automatically displayed. Please be aware that older database records might not include this information due to the feature's recent implementation.
+
 2.20.2024
 - Implemented functionality to delete a chatbot namespace from the vector database, along with all records associated with that chatbot, upon chatbot deletion.
 - The Directory Data Loader must be updated to include filename metadata to enable filtering. PR#138

--- a/dj_backend_server/api/utils/make_chain.py
+++ b/dj_backend_server/api/utils/make_chain.py
@@ -145,14 +145,11 @@ def process_text_with_llm(txt_file_path: str, mode, initial_prompt: str):
 
     # Send the formatted prompt to LLM and get the result
     llm = get_llm()
-    result = llm(prompt=initial_prompt.format(text=text), temperature=0)
+    result = llm.invoke(input=initial_prompt.format(text=text), temperature=0)
 
-    # Check if result is a string
-    if isinstance(result, str):
-        response = result
-    elif isinstance(result, dict):
-        # Extract only the response from the result
-        response = result["choices"][0]["message"]["content"]
+    # Extract the response from the result
+    if hasattr(result, "content"):
+        response = result.content
     else:
         print(
             f"Error: LLM result is not a dictionary or a string. It is a {type(result)} with value {result}"
@@ -166,6 +163,7 @@ def process_text_with_llm(txt_file_path: str, mode, initial_prompt: str):
         print(f"Write with value {txt_file_path}")
     else:
         # Write the response into a new text file
+        result_file_path = txt_file_path.replace(".txt", "_processed.txt")
         result_file_path = txt_file_path.replace(".txt", ".txt")
         with open(result_file_path, "w") as result_file:
             result_file.write(response)

--- a/dj_backend_server/api/views/views_message.py
+++ b/dj_backend_server/api/views/views_message.py
@@ -313,26 +313,34 @@ def handle_feedback(request):
 
 
 def metadata_html_append(response_json, session_id):
+    # Example logic to determine type based on response_json
+    # This is a placeholder. Adjust according to your actual logic.
+    type = "document"  # or "website", determined dynamically
+    seen_filenames = set()
+    metadata_items = []
 
     for metadata_entry in response_json.get("metadata", []):
         type = metadata_entry.get("type")
-        print(f"Type: {type}")
-        print(f"Original Filename: {metadata_entry.get('original_filename')}")
-        print(f"Source: {metadata_entry.get('source')}")
-        print(f"Page: {metadata_entry.get('page')}")
-        print(f"Bot ID: {metadata_entry.get('bot_id')}")
-        print(f"ID: {metadata_entry.get('_id')}")
+        if type == "document":
+            # if the original_filename is the same in for, then show it only one time.
+            for entry in response_json.get("metadata", []):
+                original_filename = entry.get("original_filename")
+                if original_filename not in seen_filenames:
+                    metadata_items.append(
+                        {
+                            "source": entry.get("source"),
+                            "original_filename": original_filename,
+                        }
+                    )
+                    seen_filenames.add(original_filename)
 
-    seen_filenames = set()
-    metadata_items = []
-    # if the original_filename is the same in for, then show it only one time.
-    for entry in response_json.get("metadata", []):
-        original_filename = entry.get("original_filename")
-        if original_filename not in seen_filenames:
-            metadata_items.append(
-                {"source": entry.get("source"), "original_filename": original_filename}
-            )
-            seen_filenames.add(original_filename)
+        if type == "website":
+            # if the link is the same in for, then show it only one time.
+            for entry in response_json.get("metadata", []):
+                link = entry.get("link")
+                if link not in seen_filenames:
+                    metadata_items.append({"source": entry.get("source"), "link": link})
+                    seen_filenames.add(link)
 
     return render_to_string(
         "widgets/metadata.html",
@@ -340,5 +348,6 @@ def metadata_html_append(response_json, session_id):
             "APP_URL": settings.APP_URL,
             "session_id": session_id,
             "metadata_items": metadata_items,
+            "type": type,
         },
     )

--- a/dj_backend_server/web/services/chat_history_service.py
+++ b/dj_backend_server/web/services/chat_history_service.py
@@ -54,6 +54,6 @@ def get_chat_history_for_retrieval_chain(
                 memory.save_context({"input": user_query}, {"output": entry.message})
                 user_query = None
 
-    logger.debug(f"Memory PRINT: {memory}")
+    # logger.debug(f"Memory PRINT: {memory}")
     # chat_history = memory.load_memory_variables({})
     return chat_history

--- a/dj_backend_server/web/templates/widgets/metadata.html
+++ b/dj_backend_server/web/templates/widgets/metadata.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+{% load static %}
+
+<div class="my-5">
+    <div class="w-full block h-px bg-gray-200 my-2"></div>
+    <div style="color: #000; background-color: #c3c3c3; transition: all 0.2s; padding: 0.25rem 0.5rem; border-radius: 0.375rem;">
+        <div>
+            {% for item in metadata_items %}
+                <div style="margin-bottom: 10px;">
+                    <strong>{% trans "Source:" %}</strong> {{ item.source }}<br>
+                    <strong>{% trans "Original Filename:" %}</strong> {{ item.original_filename }}
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/dj_backend_server/web/templates/widgets/metadata.html
+++ b/dj_backend_server/web/templates/widgets/metadata.html
@@ -1,15 +1,21 @@
 {% load i18n %}
 {% load static %}
 
-<div class="my-5">
-    <div class="w-full block h-px bg-white-200 my-2"></div>
-    <div style="color: #000; background-color: #c3c3c3; transition: all 0.2s; padding: 0.25rem 0.5rem; border-radius: 0.375rem;">
-        <div>
-            {% for item in metadata_items %}
-                <div style="margin-bottom: 10px;">
-                    <strong>{% trans "Source of data" %}:</strong> <a href = "{{ APP_URL }}/{{ item.source }}" target="_blank" title="{{ item.original_filename }}">{% trans "Download" %}</a><br>
+<div class="my-5" style="padding-bottom: 2.5em;">
+    {% if type == "document" %}
+        {% for item in metadata_items %}
+                <div>
+                    <strong>{% trans "Source of data" %}:</strong> <a href = "{{ APP_URL }}/{{ item.source }}" target="_blank" title="{{ item.original_filename }}">{% trans "Download" %}</a>
                 </div>
-            {% endfor %}
-        </div>
-    </div>
+        {% endfor %}
+    {% elif type == "website" %}
+        {% for item in metadata_items %}
+                <div>
+                    <strong>{% trans "Webpage to check" %}:</strong> <a href = "{{ item.link }}" target="_blank" title="{{ item.title }}">{% trans "Visit link" %}</a>
+                </div>
+        {% endfor %}
+    {% else %}    
+    <div></div>
+    {% endif %}
+            <div><small>{% trans "Generated content may be inaccurate or false. Always doublecheck the result." %}</small></div>
 </div>

--- a/dj_backend_server/web/templates/widgets/metadata.html
+++ b/dj_backend_server/web/templates/widgets/metadata.html
@@ -2,13 +2,12 @@
 {% load static %}
 
 <div class="my-5">
-    <div class="w-full block h-px bg-gray-200 my-2"></div>
+    <div class="w-full block h-px bg-white-200 my-2"></div>
     <div style="color: #000; background-color: #c3c3c3; transition: all 0.2s; padding: 0.25rem 0.5rem; border-radius: 0.375rem;">
         <div>
             {% for item in metadata_items %}
                 <div style="margin-bottom: 10px;">
-                    <strong>{% trans "Source:" %}</strong> {{ item.source }}<br>
-                    <strong>{% trans "Original Filename:" %}</strong> {{ item.original_filename }}
+                    <strong>{% trans "Source of data" %}:</strong> <a href = "{{ APP_URL }}/{{ item.source }}" target="_blank" title="{{ item.original_filename }}">{% trans "Download" %}</a><br>
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
We've recently enhanced our chat interface to display metadata values, such as the data source and web links, from our vector database when available. However, it's important to note that, as of now, there is no option to toggle this feature on or off. This means that whenever this metadata is available for newer database entries, it will be automatically displayed. Please be aware that older database records might not include this information due to the feature's recent implementation.